### PR TITLE
Fix potential multi-byte character length issue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ impl BruteForce {
     pub fn raw_next(&mut self) -> String {
         let current_chars = &self.current;
         let mut s: String = String::new();
-        let len: usize = current_chars.len();
+        let len: usize = current_chars.chars().count();
 
         for (n,c) in current_chars.chars().enumerate() {
             if n != (len - 1) {


### PR DESCRIPTION
None of your current builtin character sets use multi-byte characters, but someone may pass them in.
- - - - -
String::len() returns number of bytes, which doesn't necessarily match what is being iterated over if there are multi-byte characters.