### PR TITLE
Add bench_raw_next()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,13 @@ mod tests {
 
     #[cfg(feature = "constants")]
     #[bench]
+    fn bench_raw_next(b: &mut Bencher) {
+        let mut brute_forcer = crate::BruteForce::new(crate::UPPERCASE_CHARS);
+        b.iter(|| {brute_forcer.raw_next();});
+    }
+
+    #[cfg(feature = "constants")]
+    #[bench]
     fn bench_next(b: &mut Bencher) {
         let mut brute_forcer = crate::BruteForce::new(crate::UPPERCASE_CHARS);
         b.iter(|| brute_forcer.next());


### PR DESCRIPTION
BruteForce::next() allocates a string, which taints its performance compared to BruteForce::raw_next().